### PR TITLE
Prevent ComboBox paint on invalid size

### DIFF
--- a/AcrylicUI/Controls/AcrylicComboBox.cs
+++ b/AcrylicUI/Controls/AcrylicComboBox.cs
@@ -138,6 +138,9 @@ namespace AcrylicUI.Controls
 
         private void PaintCombobox()
         {
+            if (ClientRectangle.Width <= 0 || ClientRectangle.Height <= 0)
+                return;
+
             if (_buffer == null)
                 _buffer = new Bitmap(ClientRectangle.Width, ClientRectangle.Height);
 


### PR DESCRIPTION
A simple fix for this issue [ArgumentException on docked AcrylicComboBox when minimized the form](https://github.com/colhountech/AcrylicUI/issues/7).